### PR TITLE
Update go module and import paths to use "sdk-go" instead of "sdk"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.21
-          cache-dependency-path: "/home/runner/work/sdk/go.sum"
+          cache-dependency-path: "/home/runner/work/sdk-go/go.sum"
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.21
-          cache-dependency-path: "/home/runner/work/sdk/go.sum"
+          cache-dependency-path: "/home/runner/work/sdk-go/go.sum"
 
       - name: Check out code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@
 # The VulnCheck SDK
 Bring the VulnCheck API to your Go applications.
 
-[![Release](https://img.shields.io/github/v/release/vulncheck-oss/sdk)](https://github.com/vulncheck-oss/sdk/releases)
-[![Go Report Card](https://goreportcard.com/badge/github.com/vulncheck-oss/sdk)](https://goreportcard.com/report/github.com/vulncheck-oss/sdk)
-[![Go Reference](https://pkg.go.dev/badge/github.com/vulncheck-oss/sdk.svg)](https://pkg.go.dev/github.com/vulncheck-oss/sdk)
-[![Lint](https://github.com/vulncheck-oss/sdk/actions/workflows/lint.yml/badge.svg)](https://github.com/vulncheck-oss/sdk/actions/workflows/lint.yml)
-[![Tests](https://github.com/vulncheck-oss/sdk/actions/workflows/test.yml/badge.svg)](https://github.com/vulncheck-oss/sdk/actions/workflows/test.yml)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/vulncheck-oss/sdk/pulls)
+[![Release](https://img.shields.io/github/v/release/vulncheck-oss/sdk-go)](https://github.com/vulncheck-oss/sdk-go/releases)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vulncheck-oss/sdk-go)](https://goreportcard.com/report/github.com/vulncheck-oss/sdk-go)
+[![Go Reference](https://pkg.go.dev/badge/github.com/vulncheck-oss/sdk-go.svg)](https://pkg.go.dev/github.com/vulncheck-oss/sdk-go)
+[![Lint](https://github.com/vulncheck-oss/sdk-go/actions/workflows/lint.yml/badge.svg)](https://github.com/vulncheck-oss/sdk-go/actions/workflows/lint.yml)
+[![Tests](https://github.com/vulncheck-oss/sdk-go/actions/workflows/test.yml/badge.svg)](https://github.com/vulncheck-oss/sdk-go/actions/workflows/test.yml)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/vulncheck-oss/sdk-go/pulls)
 
 ## Installation
 
 ```bash
-go get github.com/vulncheck-oss/sdk
+go get github.com/vulncheck-oss/sdk-go
 ```
 
 
@@ -28,7 +28,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/vulncheck-oss/sdk"
+	"github.com/vulncheck-oss/sdk-go"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vulncheck-oss/sdk
+module github.com/vulncheck-oss/sdk-go
 
 go 1.21
 

--- a/index_funcs.go
+++ b/index_funcs.go
@@ -3,7 +3,7 @@ package sdk
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/vulncheck-oss/sdk/pkg/client"
+	"github.com/vulncheck-oss/sdk-go/pkg/client"
 	"net/http"
 	"net/url"
 )


### PR DESCRIPTION
we are updating the namepsace/import module
it will no longer be https://github.com/vulncheck-oss/sdk, but https://github.com/vulncheck-oss/sdk-go

for example:
```go
require (
	github.com/vulncheck-oss/sdk-go v1.6.2
)
```